### PR TITLE
Fix declared dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,12 +60,12 @@ dependencies {
     runtimeImplementation gradleApi()
 
     baseImplementation gradleApi()
-    baseImplementation(project(":")) {
+    baseApi(project(":")) {
         capabilities {
             requireCapability("net.neoforged:groovydslimprover-runtime")
         }
     }
-    baseImplementation(project(":"))
+    baseApi(project(":"))
 
     compileOnly 'org.jetbrains:annotations:24.0.0'
 


### PR DESCRIPTION
It seems that in my last PR I forgot to make the `base` variant expose the other two as API - given that this is how they're meant to be consumed.