### PR TITLE
Add support for generic entries in FilesOrEntries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,3 +120,5 @@ publishing {
         maven gradleutils.publishingMaven
     }
 }
+
+tasks.assemble.dependsOn(tasks.withType(Jar))

--- a/src/base/groovy/net/minecraftforge/gdi/BaseDSLElementWithFilesAndEntries.groovy
+++ b/src/base/groovy/net/minecraftforge/gdi/BaseDSLElementWithFilesAndEntries.groovy
@@ -16,7 +16,7 @@ import org.gradle.api.provider.ListProperty
  * @param <TSelf> The type of the implementing class.
  */
 @CompileStatic
-interface BaseDSLElementWithFilesAndEntries<TSelf extends BaseDSLElementWithFilesAndEntries<TSelf>> extends BaseDSLElement<TSelf> {
+interface BaseDSLElementWithFilesAndEntries<TSelf extends BaseDSLElementWithFilesAndEntries<TSelf, TEntries>, TEntries> extends BaseDSLElement<TSelf> {
 
     /**
      * @return The files which contain entries relevant to this extension.
@@ -28,7 +28,7 @@ interface BaseDSLElementWithFilesAndEntries<TSelf extends BaseDSLElementWithFile
      * @return The raw additional entries relevant to this extension.
      */
     @DSLProperty(propertyName = "entry")
-    ListProperty<String> getEntries()
+    ListProperty<TEntries> getEntries()
 
     /**
      * Indicates if either at least one file is specified or at least one additional raw entry is specified.


### PR DESCRIPTION
This adds support for entries being generically defined objects not just strings.
Should make adding complex entries a lot easier.